### PR TITLE
Flexible input sources: dSYM bundles, directory/UUID lookup, debuglink, stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Apple's `atos` is useful, but it is tightly coupled to Apple's runtime environme
 - Local symbolication from executables, object files, and dSYM payloads
 - Inlined call-stack expansion for DWARF frames, like `atos`
 - Multi-address lookups in a single invocation
+- Addresses from the command line, a file (`--input`), or stdin (streamed in text mode)
+- `.dSYM` bundle directories, or a directory searched by `--uuid` / build-id
+- Separate ELF debug files via `.gnu_debuglink` or build-id
 - Mach-O fat binaries with explicit slice selection
 - Machine-readable integration through JSON output
 - Debugging symbolication decisions through verbose diagnostics
@@ -61,15 +64,16 @@ atosl -o <OBJECT_PATH> -l <LOAD_ADDRESS> [OPTIONS] <ADDRESS>...
 
 Required arguments:
 
-- `-o, --object <OBJECT_PATH>`: object file, executable, dSYM payload, or `.dSYM` bundle directory
+- `-o, --object <OBJECT_PATH>`: object file, executable, dSYM payload, `.dSYM` bundle directory, or a directory to search with `--uuid`
 - `-l, --load-address <LOAD_ADDRESS>`: runtime image load address
-- `<ADDRESS>...`: one or more addresses to symbolize
+- `<ADDRESS>...`: addresses to symbolize; omit to read from `--input` or stdin
 
 Key options:
 
 - `-f, --file-offsets`: interpret addresses as file offsets
 - `-a, --arch <ARCH>`: choose a Mach-O slice in a fat binary
-- `--uuid <UUID>`: choose a Mach-O slice by UUID
+- `--uuid <UUID>`: choose a Mach-O slice by UUID, or select a file from a directory by UUID/build-id
+- `-i, --input <FILE>`: read addresses from a file (defaults to stdin when no addresses are given)
 - `--format <text|json|json-pretty>`: select output format
 - `-v, --verbose`: print resolver diagnostics to stderr
 
@@ -97,6 +101,24 @@ Select a specific fat Mach-O slice:
 
 ```bash
 atosl -o Flutter -l 0x100000000 --arch arm64 0x100001234
+```
+
+Read addresses from stdin (text output streams one result per line):
+
+```bash
+printf '0x100001234\n0x100004321\n' | atosl -o MyApp.app.dSYM -l 0x100000000
+```
+
+Read addresses from a file:
+
+```bash
+atosl -o MyApp.app.dSYM -l 0x100000000 --input crash_addresses.txt
+```
+
+Search a directory of dSYMs/binaries for the matching image by UUID (or build-id):
+
+```bash
+atosl -o ./symbols -l 0x100000000 --uuid 34FBD46D4A1F3B41A0F14E57D7E25B04 0x100001234
 ```
 
 Emit machine-readable output:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ atosl -o <OBJECT_PATH> -l <LOAD_ADDRESS> [OPTIONS] <ADDRESS>...
 
 Required arguments:
 
-- `-o, --object <OBJECT_PATH>`: object file, executable, or dSYM payload
+- `-o, --object <OBJECT_PATH>`: object file, executable, dSYM payload, or `.dSYM` bundle directory
 - `-l, --load-address <LOAD_ADDRESS>`: runtime image load address
 - `<ADDRESS>...`: one or more addresses to symbolize
 
@@ -85,6 +85,12 @@ Symbolize multiple addresses:
 
 ```bash
 atosl -o MyApp.app/MyApp -l 0x100000000 0x100001234 0x100004321 0x100008888
+```
+
+Point directly at a `.dSYM` bundle (the DWARF payload is located automatically):
+
+```bash
+atosl -o MyApp.app.dSYM -l 0x100000000 0x100001234
 ```
 
 Select a specific fat Mach-O slice:

--- a/benches/batch_symbolize.rs
+++ b/benches/batch_symbolize.rs
@@ -17,6 +17,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         arch: None,
         uuid: None,
         format: OutputFormat::Json,
+        input: None,
     };
 
     c.bench_function("symbolize_64_addresses", |b| {

--- a/src/atosl.rs
+++ b/src/atosl.rs
@@ -383,10 +383,14 @@ fn find_object_by_id(dir: &Path, uuid: &str) -> Result<PathBuf> {
 fn resolve_debug_companion(path: &Path) -> PathBuf {
     let keep = || path.to_path_buf();
 
-    let Ok(data) = fs::read(path) else {
+    let Ok(handle) = fs::File::open(path) else {
         return keep();
     };
-    let Ok(file) = object::File::parse(data.as_slice()) else {
+    // mmap so checking large binaries only touches headers, not the whole file.
+    let Ok(mmap) = (unsafe { memmap2::Mmap::map(&handle) }) else {
+        return keep();
+    };
+    let Ok(file) = object::File::parse(&*mmap) else {
         return keep();
     };
     if is_object_dwarf(&file) {

--- a/src/atosl.rs
+++ b/src/atosl.rs
@@ -105,19 +105,19 @@ pub fn run(options: SymbolizeOptions) -> Result<i32> {
 }
 
 pub fn symbolize_path(options: &SymbolizeOptions) -> Result<SymbolizeReport> {
-    let file = fs::File::open(&options.object_path).with_context(|| {
-        format!(
-            "failed to open object file: {}",
-            options.object_path.display()
-        )
-    })?;
+    let object_path = resolve_object_path(&options.object_path)?;
+    if options.verbose && object_path != options.object_path {
+        eprintln!("resolved_object: {}", object_path.display());
+    }
+    let file = fs::File::open(&object_path)
+        .with_context(|| format!("failed to open object file: {}", object_path.display()))?;
     let mmap = unsafe { memmap2::Mmap::map(&file) }
-        .with_context(|| format!("failed to memory-map: {}", options.object_path.display()))?;
+        .with_context(|| format!("failed to memory-map: {}", object_path.display()))?;
 
     let parsed_uuid_filter = options.uuid.as_deref().map(parse_uuid_string).transpose()?;
     let resolved = resolve_object_from_data(
         &mmap,
-        &options.object_path,
+        &object_path,
         options.arch.as_deref(),
         parsed_uuid_filter,
         options.verbose,
@@ -164,11 +164,70 @@ pub fn symbolize_path(options: &SymbolizeOptions) -> Result<SymbolizeReport> {
         .collect();
 
     Ok(SymbolizeReport {
-        object_path: options.object_path.display().to_string(),
+        object_path: object_path.display().to_string(),
         object_name: resolved.object_name,
         selected_slice: resolved.selected_slice,
         frames,
     })
+}
+
+// Accepts either a Mach-O/ELF file or a `.dSYM` bundle directory and returns
+// the path to the binary that actually carries the symbols.
+fn resolve_object_path(path: &Path) -> Result<PathBuf> {
+    if path.is_file() {
+        return Ok(path.to_path_buf());
+    }
+
+    if path.is_dir() {
+        let dwarf_dir = path.join("Contents/Resources/DWARF");
+        if dwarf_dir.is_dir() {
+            return select_dwarf_payload(&dwarf_dir, path);
+        }
+        return Err(anyhow!(
+            "{} is a directory but not a dSYM bundle (missing Contents/Resources/DWARF)",
+            path.display()
+        ));
+    }
+
+    Err(anyhow!("object path does not exist: {}", path.display()))
+}
+
+fn select_dwarf_payload(dwarf_dir: &Path, bundle: &Path) -> Result<PathBuf> {
+    let mut payloads = fs::read_dir(dwarf_dir)
+        .with_context(|| format!("failed to read dSYM payload dir: {}", dwarf_dir.display()))?
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| path.is_file())
+        .collect::<Vec<_>>();
+    payloads.sort();
+
+    match payloads.len() {
+        0 => Err(anyhow!("no DWARF payload found in {}", dwarf_dir.display())),
+        1 => Ok(payloads.remove(0)),
+        _ => {
+            // A fat dSYM ships one payload named after the bundle (Foo.dSYM -> Foo).
+            let base = bundle
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(|name| name.trim_end_matches(".dSYM"));
+            if let Some(base) = base {
+                if let Some(found) = payloads
+                    .iter()
+                    .find(|path| path.file_name().and_then(|name| name.to_str()) == Some(base))
+                {
+                    return Ok(found.clone());
+                }
+            }
+            Err(anyhow!(
+                "multiple DWARF payloads in {}; pass the file directly:\n{}",
+                dwarf_dir.display(),
+                payloads
+                    .iter()
+                    .map(|path| format!("- {}", path.display()))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            ))
+        }
+    }
 }
 
 fn emit_report(report: &SymbolizeReport, format: OutputFormat, verbose: bool) {

--- a/src/atosl.rs
+++ b/src/atosl.rs
@@ -330,7 +330,7 @@ fn parse_address_token(token: &str) -> Result<u64, String> {
 // that actually carries the symbols.
 fn resolve_object_path(path: &Path, uuid: Option<&str>) -> Result<PathBuf> {
     if path.is_file() {
-        return Ok(path.to_path_buf());
+        return Ok(resolve_debug_companion(path));
     }
 
     if path.is_dir() {
@@ -375,6 +375,78 @@ fn find_object_by_id(dir: &Path, uuid: &str) -> Result<PathBuf> {
         dir.display(),
         uuid
     ))
+}
+
+// A stripped ELF can point at its DWARF in a separate file via `.gnu_debuglink`
+// or its build-id. When the given file carries no DWARF, follow those hints to a
+// companion debug file that exists; otherwise keep the original path.
+fn resolve_debug_companion(path: &Path) -> PathBuf {
+    let keep = || path.to_path_buf();
+
+    let Ok(data) = fs::read(path) else {
+        return keep();
+    };
+    let Ok(file) = object::File::parse(data.as_slice()) else {
+        return keep();
+    };
+    if is_object_dwarf(&file) {
+        return keep();
+    }
+
+    if let Some(name) = read_debuglink_name(&file) {
+        if let Some(found) = search_debuglink_paths(path, &name) {
+            return found;
+        }
+    }
+
+    if let Ok(Some(build_id)) = file.build_id() {
+        let candidate =
+            PathBuf::from("/usr/lib/debug/.build-id").join(build_id_debug_subpath(build_id));
+        if candidate.is_file() {
+            return candidate;
+        }
+    }
+
+    keep()
+}
+
+fn read_debuglink_name<'data>(file: &object::File<'data, &'data [u8]>) -> Option<String> {
+    let section = file.section_by_name(".gnu_debuglink")?;
+    let data = section.data().ok()?;
+    let end = data
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(data.len());
+    let name = std::str::from_utf8(&data[..end]).ok()?;
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
+}
+
+fn search_debuglink_paths(binary: &Path, debug_name: &str) -> Option<PathBuf> {
+    let dir = binary.parent().unwrap_or_else(|| Path::new("."));
+    let mut candidates = vec![dir.join(debug_name), dir.join(".debug").join(debug_name)];
+
+    if let Ok(absolute) = dir.canonicalize() {
+        let stripped = absolute.strip_prefix("/").unwrap_or(&absolute);
+        candidates.push(
+            PathBuf::from("/usr/lib/debug")
+                .join(stripped)
+                .join(debug_name),
+        );
+    }
+
+    candidates.into_iter().find(|candidate| candidate.is_file())
+}
+
+fn build_id_debug_subpath(build_id: &[u8]) -> PathBuf {
+    let hex = format_hex(build_id);
+    match hex.split_at_checked(2) {
+        Some((prefix, rest)) => PathBuf::from(prefix).join(format!("{rest}.debug")),
+        None => PathBuf::from(format!("{hex}.debug")),
+    }
 }
 
 fn collect_candidate_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {

--- a/src/atosl.rs
+++ b/src/atosl.rs
@@ -7,6 +7,7 @@ use object::{Object, ObjectSection, ObjectSegment, SymbolMap, SymbolMapName};
 use serde::Serialize;
 use std::borrow;
 use std::fs;
+use std::io::{self, BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
 type DwarfContext<'data> = addr2line::Context<EndianSlice<'data, RunTimeEndian>>;
@@ -36,6 +37,9 @@ pub struct SymbolizeOptions {
     pub arch: Option<String>,
     pub uuid: Option<String>,
     pub format: OutputFormat,
+    /// When no addresses are passed positionally, read them from this file, or
+    /// from stdin when `None`.
+    pub input: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -99,12 +103,131 @@ struct ResolvedObject<'data> {
 }
 
 pub fn run(options: SymbolizeOptions) -> Result<i32> {
-    let report = symbolize_path(&options)?;
+    // Addresses given on the command line use the batch path.
+    if !options.addresses.is_empty() {
+        let report = symbolize_path(&options)?;
+        emit_report(&report, options.format, options.verbose);
+        return Ok(0);
+    }
+
+    // Otherwise read addresses from a file or stdin. Text output streams a
+    // result per address; JSON collects a single document.
+    match options.format {
+        OutputFormat::Text => run_streaming_text(&options),
+        OutputFormat::Json | OutputFormat::JsonPretty => run_collected_input(&options),
+    }
+}
+
+pub fn symbolize_path(options: &SymbolizeOptions) -> Result<SymbolizeReport> {
+    with_symbolizer(options, |symbolizer, object_path, selected_slice| {
+        let frames = options
+            .addresses
+            .iter()
+            .copied()
+            .map(|requested_address| {
+                symbolizer.symbolize(
+                    options.load_address,
+                    requested_address,
+                    options.file_offsets,
+                )
+            })
+            .collect();
+
+        SymbolizeReport {
+            object_path,
+            object_name: symbolizer.object_name.to_string(),
+            selected_slice,
+            frames,
+        }
+    })
+}
+
+fn run_streaming_text(options: &SymbolizeOptions) -> Result<i32> {
+    with_symbolizer(
+        options,
+        |symbolizer, object_path, selected_slice| -> Result<i32> {
+            if options.verbose {
+                emit_text_header(&object_path, selected_slice.as_ref());
+            }
+            for_each_input_address(options.input.as_deref(), |parsed| {
+                emit_text_outcome(
+                    &symbolizer.symbolize_parsed(options, parsed),
+                    options.verbose,
+                );
+            })?;
+            Ok(0)
+        },
+    )?
+}
+
+fn run_collected_input(options: &SymbolizeOptions) -> Result<i32> {
+    let report = with_symbolizer(
+        options,
+        |symbolizer, object_path, selected_slice| -> Result<SymbolizeReport> {
+            let mut frames = Vec::new();
+            for_each_input_address(options.input.as_deref(), |parsed| {
+                frames.push(symbolizer.symbolize_parsed(options, parsed));
+            })?;
+            Ok(SymbolizeReport {
+                object_path,
+                object_name: symbolizer.object_name.to_string(),
+                selected_slice,
+                frames,
+            })
+        },
+    )??;
     emit_report(&report, options.format, options.verbose);
     Ok(0)
 }
 
-pub fn symbolize_path(options: &SymbolizeOptions) -> Result<SymbolizeReport> {
+struct Symbolizer<'a> {
+    object_name: &'a str,
+    context: Option<&'a DwarfContext<'a>>,
+    symbol_map: &'a SymbolMap<SymbolMapName<'a>>,
+    text_vmaddr: u64,
+}
+
+impl Symbolizer<'_> {
+    fn symbolize(
+        &self,
+        load_address: u64,
+        requested_address: u64,
+        file_offsets: bool,
+    ) -> SymbolizeOutcome {
+        symbolize_address(
+            self.object_name,
+            self.context,
+            self.symbol_map,
+            load_address,
+            requested_address,
+            self.text_vmaddr,
+            file_offsets,
+        )
+    }
+
+    fn symbolize_parsed(
+        &self,
+        options: &SymbolizeOptions,
+        parsed: Result<u64, String>,
+    ) -> SymbolizeOutcome {
+        match parsed {
+            Ok(address) => self.symbolize(options.load_address, address, options.file_offsets),
+            Err(error) => SymbolizeOutcome::Unresolved {
+                requested_address: 0,
+                error,
+            },
+        }
+    }
+}
+
+// Loads the object and DWARF context once, then hands a reusable symbolizer to
+// `body`. Keeping the borrowed state inside one stack frame avoids a
+// self-referential struct (the context borrows the sections, which borrow the
+// mmap).
+fn with_symbolizer<T>(
+    options: &SymbolizeOptions,
+    body: impl FnOnce(&Symbolizer<'_>, String, Option<SelectedSlice>) -> T,
+) -> Result<T> {
     let object_path = resolve_object_path(&options.object_path)?;
     if options.verbose && object_path != options.object_path {
         eprintln!("resolved_object: {}", object_path.display());
@@ -131,8 +254,6 @@ pub fn symbolize_path(options: &SymbolizeOptions) -> Result<SymbolizeReport> {
     let text_vmaddr = find_text_vmaddr(&resolved.object)?;
     let symbol_map = resolved.object.symbol_map();
 
-    // Building the DWARF context once amortizes unit indexing and line-program
-    // parsing across every requested address.
     let dwarf_sections = if is_object_dwarf(&resolved.object) {
         Some(load_dwarf_sections(&resolved.object)?)
     } else {
@@ -146,29 +267,59 @@ pub fn symbolize_path(options: &SymbolizeOptions) -> Result<SymbolizeReport> {
         None => None,
     };
 
-    let frames = options
-        .addresses
-        .iter()
-        .copied()
-        .map(|requested_address| {
-            symbolize_address(
-                &resolved.object_name,
-                context.as_ref(),
-                &symbol_map,
-                options.load_address,
-                requested_address,
-                text_vmaddr,
-                options.file_offsets,
-            )
-        })
-        .collect();
+    let symbolizer = Symbolizer {
+        object_name: &resolved.object_name,
+        context: context.as_ref(),
+        symbol_map: &symbol_map,
+        text_vmaddr,
+    };
 
-    Ok(SymbolizeReport {
-        object_path: object_path.display().to_string(),
-        object_name: resolved.object_name,
-        selected_slice: resolved.selected_slice,
-        frames,
-    })
+    Ok(body(
+        &symbolizer,
+        object_path.display().to_string(),
+        resolved.selected_slice.clone(),
+    ))
+}
+
+fn for_each_input_address(
+    input: Option<&Path>,
+    mut handle: impl FnMut(Result<u64, String>),
+) -> Result<()> {
+    match input {
+        Some(path) => {
+            let file = fs::File::open(path)
+                .with_context(|| format!("failed to open address input: {}", path.display()))?;
+            read_addresses(BufReader::new(file), &mut handle)
+        }
+        None => {
+            let stdin = io::stdin();
+            read_addresses(stdin.lock(), &mut handle)
+        }
+    }
+}
+
+fn read_addresses(
+    reader: impl BufRead,
+    handle: &mut impl FnMut(Result<u64, String>),
+) -> Result<()> {
+    for line in reader.lines() {
+        let line = line.context("failed to read address input")?;
+        for token in line.split_whitespace() {
+            handle(parse_address_token(token));
+        }
+    }
+    Ok(())
+}
+
+fn parse_address_token(token: &str) -> Result<u64, String> {
+    let parsed = match token
+        .strip_prefix("0x")
+        .or_else(|| token.strip_prefix("0X"))
+    {
+        Some(hex) => u64::from_str_radix(hex, 16),
+        None => token.parse::<u64>(),
+    };
+    parsed.map_err(|err| format!("invalid address '{token}': {err}"))
 }
 
 // Accepts either a Mach-O/ELF file or a `.dSYM` bundle directory and returns
@@ -240,43 +391,50 @@ fn emit_report(report: &SymbolizeReport, format: OutputFormat, verbose: bool) {
 
 fn emit_text_report(report: &SymbolizeReport, verbose: bool) {
     if verbose {
-        eprintln!("object: {}", report.object_path);
-        if let Some(selected_slice) = &report.selected_slice {
-            eprintln!(
-                "selected_slice: arch={} uuid={}",
-                selected_slice.arch,
-                selected_slice.uuid.as_deref().unwrap_or("-")
-            );
-        }
+        emit_text_header(&report.object_path, report.selected_slice.as_ref());
     }
-
     for frame in &report.frames {
-        match frame {
-            SymbolizeOutcome::Resolved(frame) => {
-                if verbose {
-                    eprintln!(
-                        "frame: requested=0x{requested:016x} lookup=0x{lookup:016x} resolver={resolver:?} status=resolved",
-                        requested = frame.requested_address,
-                        lookup = frame.lookup_address,
-                        resolver = frame.resolver,
-                    );
-                }
-                println!("{}", format_text_frame(frame));
-                for inline in &frame.inlined_by {
-                    println!("{}", format_inline_frame(inline, &frame.object_name));
-                }
+        emit_text_outcome(frame, verbose);
+    }
+}
+
+fn emit_text_header(object_path: &str, selected_slice: Option<&SelectedSlice>) {
+    eprintln!("object: {object_path}");
+    if let Some(selected_slice) = selected_slice {
+        eprintln!(
+            "selected_slice: arch={} uuid={}",
+            selected_slice.arch,
+            selected_slice.uuid.as_deref().unwrap_or("-")
+        );
+    }
+}
+
+fn emit_text_outcome(outcome: &SymbolizeOutcome, verbose: bool) {
+    match outcome {
+        SymbolizeOutcome::Resolved(frame) => {
+            if verbose {
+                eprintln!(
+                    "frame: requested=0x{requested:016x} lookup=0x{lookup:016x} resolver={resolver:?} status=resolved",
+                    requested = frame.requested_address,
+                    lookup = frame.lookup_address,
+                    resolver = frame.resolver,
+                );
             }
-            SymbolizeOutcome::Unresolved {
-                requested_address,
-                error,
-            } => {
-                if verbose {
-                    eprintln!(
-                        "frame: requested=0x{requested_address:016x} status=unresolved error={error}"
-                    );
-                }
-                println!("N/A - {error}");
+            println!("{}", format_text_frame(frame));
+            for inline in &frame.inlined_by {
+                println!("{}", format_inline_frame(inline, &frame.object_name));
             }
+        }
+        SymbolizeOutcome::Unresolved {
+            requested_address,
+            error,
+        } => {
+            if verbose {
+                eprintln!(
+                    "frame: requested=0x{requested_address:016x} status=unresolved error={error}"
+                );
+            }
+            println!("N/A - {error}");
         }
     }
 }

--- a/src/atosl.rs
+++ b/src/atosl.rs
@@ -228,7 +228,7 @@ fn with_symbolizer<T>(
     options: &SymbolizeOptions,
     body: impl FnOnce(&Symbolizer<'_>, String, Option<SelectedSlice>) -> T,
 ) -> Result<T> {
-    let object_path = resolve_object_path(&options.object_path)?;
+    let object_path = resolve_object_path(&options.object_path, options.uuid.as_deref())?;
     if options.verbose && object_path != options.object_path {
         eprintln!("resolved_object: {}", object_path.display());
     }
@@ -237,7 +237,10 @@ fn with_symbolizer<T>(
     let mmap = unsafe { memmap2::Mmap::map(&file) }
         .with_context(|| format!("failed to memory-map: {}", object_path.display()))?;
 
-    let parsed_uuid_filter = options.uuid.as_deref().map(parse_uuid_string).transpose()?;
+    let parsed_uuid_filter = match options.uuid.as_deref() {
+        Some(value) => parse_uuid_filter(value)?,
+        None => None,
+    };
     let resolved = resolve_object_from_data(
         &mmap,
         &object_path,
@@ -322,9 +325,10 @@ fn parse_address_token(token: &str) -> Result<u64, String> {
     parsed.map_err(|err| format!("invalid address '{token}': {err}"))
 }
 
-// Accepts either a Mach-O/ELF file or a `.dSYM` bundle directory and returns
-// the path to the binary that actually carries the symbols.
-fn resolve_object_path(path: &Path) -> Result<PathBuf> {
+// Accepts a Mach-O/ELF file, a `.dSYM` bundle directory, or (with `uuid`) a
+// directory of binaries/dSYMs to search, and returns the path to the binary
+// that actually carries the symbols.
+fn resolve_object_path(path: &Path, uuid: Option<&str>) -> Result<PathBuf> {
     if path.is_file() {
         return Ok(path.to_path_buf());
     }
@@ -334,13 +338,124 @@ fn resolve_object_path(path: &Path) -> Result<PathBuf> {
         if dwarf_dir.is_dir() {
             return select_dwarf_payload(&dwarf_dir, path);
         }
+        if let Some(uuid) = uuid {
+            return find_object_by_id(path, uuid);
+        }
         return Err(anyhow!(
-            "{} is a directory but not a dSYM bundle (missing Contents/Resources/DWARF)",
+            "{} is a directory; pass --uuid to select a matching binary/dSYM, or point at a file",
             path.display()
         ));
     }
 
     Err(anyhow!("object path does not exist: {}", path.display()))
+}
+
+// Walks `dir` for a binary or dSYM payload whose Mach-O UUID or ELF build-id
+// matches `uuid` (compared as hex, ignoring case and separators).
+fn find_object_by_id(dir: &Path, uuid: &str) -> Result<PathBuf> {
+    let wanted = normalize_hex_id(uuid);
+    if wanted.is_empty() {
+        return Err(anyhow!("invalid --uuid value: '{uuid}'"));
+    }
+
+    let mut candidates = Vec::new();
+    collect_candidate_files(dir, &mut candidates)?;
+    candidates.sort();
+
+    for candidate in &candidates {
+        if let Ok(data) = fs::read(candidate) {
+            if collect_module_ids(&data).contains(&wanted) {
+                return Ok(candidate.clone());
+            }
+        }
+    }
+
+    Err(anyhow!(
+        "no binary or dSYM under {} matched uuid {}",
+        dir.display(),
+        uuid
+    ))
+}
+
+fn collect_candidate_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    let entries = fs::read_dir(dir)
+        .with_context(|| format!("failed to read directory: {}", dir.display()))?;
+    for entry in entries {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            continue;
+        }
+        let path = entry.path();
+        if file_type.is_dir() {
+            collect_candidate_files(&path, out)?;
+        } else if file_type.is_file() {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn collect_module_ids(data: &[u8]) -> Vec<String> {
+    match object::FileKind::parse(data) {
+        Ok(object::FileKind::MachOFat32) => FatHeader::parse_arch32(data)
+            .map(|arches| fat_slice_ids(arches, data))
+            .unwrap_or_default(),
+        Ok(object::FileKind::MachOFat64) => FatHeader::parse_arch64(data)
+            .map(|arches| fat_slice_ids(arches, data))
+            .unwrap_or_default(),
+        Ok(_) => slice_ids(data),
+        Err(_) => Vec::new(),
+    }
+}
+
+fn fat_slice_ids<A: FatArch>(arches: &[A], data: &[u8]) -> Vec<String> {
+    arches
+        .iter()
+        .filter_map(|arch| arch.data(data).ok())
+        .flat_map(slice_ids)
+        .collect()
+}
+
+fn slice_ids(data: &[u8]) -> Vec<String> {
+    let Ok(file) = object::File::parse(data) else {
+        return Vec::new();
+    };
+    let mut ids = Vec::new();
+    if let Ok(Some(uuid)) = file.mach_uuid() {
+        ids.push(format_hex(&uuid));
+    }
+    if let Ok(Some(build_id)) = file.build_id() {
+        ids.push(format_hex(build_id));
+    }
+    ids
+}
+
+fn format_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn normalize_hex_id(value: &str) -> String {
+    value
+        .chars()
+        .filter(|c| c.is_ascii_hexdigit())
+        .flat_map(|c| c.to_lowercase())
+        .collect()
+}
+
+// A 16-byte value is a Mach-O slice UUID and is used to pick a fat slice and to
+// validate non-fat files. Other hex lengths are build-ids used only to select a
+// file from a directory, so they impose no slice filter here.
+fn parse_uuid_filter(value: &str) -> Result<Option<[u8; 16]>> {
+    let hex = normalize_hex_id(value);
+    if hex.is_empty() || value.chars().any(|c| c != '-' && !c.is_ascii_hexdigit()) {
+        return Err(anyhow!("invalid uuid format: '{value}'"));
+    }
+    if hex.len() == 32 {
+        Ok(Some(parse_uuid_string(value)?))
+    } else {
+        Ok(None)
+    }
 }
 
 fn select_dwarf_payload(dwarf_dir: &Path, bundle: &Path) -> Result<PathBuf> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 //!     arch: Some("arm64".to_string()),
 //!     uuid: None,
 //!     format: OutputFormat::Json,
+//!     input: None,
 //! })?;
 //!
 //! println!("{:#?}", report.frames);

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,9 +31,15 @@ struct Args {
     #[arg(short = 'l', long = "load-address", value_parser = parse_address_string)]
     load_address: u64,
 
-    /// Addresses that should be symbolized
-    #[arg(value_parser = parse_address_string, required = true)]
+    /// Addresses that should be symbolized. When omitted, addresses are read
+    /// from --input or stdin (one or more per line, whitespace-separated).
+    #[arg(value_parser = parse_address_string)]
     addresses: Vec<u64>,
+
+    /// Read addresses from this file instead of the command line (use stdin
+    /// when neither addresses nor this flag are given)
+    #[arg(short = 'i', long = "input")]
+    input: Option<PathBuf>,
 
     /// Enable verbose diagnostics
     #[arg(short, long)]
@@ -78,6 +84,7 @@ fn main() {
         arch: args.arch,
         uuid: args.uuid,
         format: args.format.into(),
+        input: args.input,
     };
 
     let exit_code = match atosl::atosl::run(options) {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -124,6 +124,79 @@ fn cli_reads_addresses_from_input_file() {
         .stdout(predicates::str::contains("(in fixture_bin)"));
 }
 
+#[test]
+fn cli_finds_object_in_directory_by_build_id() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let src = tempdir.path().join("f.c");
+    fs::write(
+        &src,
+        "int fixture_target(void){return 7;}\nint main(void){return fixture_target();}\n",
+    )
+    .unwrap();
+
+    let dir = tempdir.path().join("symbols");
+    fs::create_dir_all(&dir).unwrap();
+    let alpha = dir.join("alpha");
+    let beta = dir.join("beta");
+    let id_beta = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    build_with_build_id(&src, &alpha, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    build_with_build_id(&src, &beta, id_beta);
+
+    let address = symbol_addr(&beta, "fixture_target");
+    let load = text_addr(&beta);
+
+    Command::cargo_bin("atosl")
+        .unwrap()
+        .args([
+            "-o",
+            dir.to_str().unwrap(),
+            "--uuid",
+            id_beta,
+            "-l",
+            &format!("0x{load:x}"),
+            &format!("0x{address:x}"),
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("(in beta)"));
+}
+
+fn build_with_build_id(src: &Path, out: &Path, build_id: &str) {
+    let status = ProcessCommand::new("cc")
+        .args([
+            "-g",
+            "-O0",
+            &format!("-Wl,--build-id=0x{build_id}"),
+            src.to_str().unwrap(),
+            "-o",
+            out.to_str().unwrap(),
+        ])
+        .status()
+        .unwrap();
+    assert!(status.success(), "failed to build {}", out.display());
+}
+
+fn symbol_addr(path: &Path, name: &str) -> u64 {
+    let bytes = fs::read(path).unwrap();
+    let object = object::File::parse(bytes.as_slice()).unwrap();
+    object
+        .symbols()
+        .chain(object.dynamic_symbols())
+        .find(|symbol| symbol.name().map(|n| n.contains(name)).unwrap_or(false))
+        .map(|symbol| symbol.address())
+        .unwrap()
+}
+
+fn text_addr(path: &Path) -> u64 {
+    let bytes = fs::read(path).unwrap();
+    let object = object::File::parse(bytes.as_slice()).unwrap();
+    object
+        .section_by_name(".text")
+        .or_else(|| object.section_by_name("__text"))
+        .map(|section| section.address())
+        .unwrap()
+}
+
 struct Fixture {
     _tempdir: TempDir,
     binary_path: PathBuf,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -126,6 +126,11 @@ fn cli_reads_addresses_from_input_file() {
 
 #[test]
 fn cli_finds_object_in_directory_by_build_id() {
+    // build-id is an ELF/GNU-ld concept; skip on non-Linux toolchains.
+    if !cfg!(target_os = "linux") {
+        return;
+    }
+
     let tempdir = tempfile::tempdir().unwrap();
     let src = tempdir.path().join("f.c");
     fs::write(
@@ -159,6 +164,64 @@ fn cli_finds_object_in_directory_by_build_id() {
         .assert()
         .success()
         .stdout(predicates::str::contains("(in beta)"));
+}
+
+#[test]
+fn cli_follows_gnu_debuglink_to_separate_debug_file() {
+    // .gnu_debuglink + objcopy are ELF/binutils features; skip elsewhere.
+    if !cfg!(target_os = "linux") {
+        return;
+    }
+
+    let tempdir = tempfile::tempdir().unwrap();
+    let src = tempdir.path().join("f.c");
+    fs::write(
+        &src,
+        "int fixture_target(void){return 7;}\nint main(void){return fixture_target();}\n",
+    )
+    .unwrap();
+
+    let bin = tempdir.path().join("app");
+    let status = ProcessCommand::new("cc")
+        .args([
+            "-g",
+            "-O0",
+            src.to_str().unwrap(),
+            "-o",
+            bin.to_str().unwrap(),
+        ])
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    run_objcopy(&["--only-keep-debug", "app", "app.debug"], tempdir.path());
+    run_objcopy(&["--strip-debug", "app"], tempdir.path());
+    run_objcopy(&["--add-gnu-debuglink=app.debug", "app"], tempdir.path());
+
+    let address = symbol_addr(&bin, "fixture_target");
+    let load = text_addr(&bin);
+
+    Command::cargo_bin("atosl")
+        .unwrap()
+        .args([
+            "-o",
+            bin.to_str().unwrap(),
+            "-l",
+            &format!("0x{load:x}"),
+            &format!("0x{address:x}"),
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("(in app.debug)"));
+}
+
+fn run_objcopy(args: &[&str], cwd: &Path) {
+    let status = ProcessCommand::new("objcopy")
+        .args(args)
+        .current_dir(cwd)
+        .status()
+        .unwrap();
+    assert!(status.success(), "objcopy {args:?} failed");
 }
 
 fn build_with_build_id(src: &Path, out: &Path, build_id: &str) {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -53,6 +53,35 @@ fn cli_emits_text_for_resolved_symbol() {
         .stdout(predicates::str::contains("(in fixture_bin)"));
 }
 
+#[test]
+fn cli_resolves_dsym_bundle_directory() {
+    let fixture = Fixture::build().unwrap();
+    let address = fixture.symbol_address("fixture_target").unwrap();
+
+    let dwarf_dir = fixture
+        .binary_path()
+        .parent()
+        .unwrap()
+        .join("Fixture.dSYM/Contents/Resources/DWARF");
+    fs::create_dir_all(&dwarf_dir).unwrap();
+    let payload = dwarf_dir.join("fixture_bin");
+    fs::copy(fixture.binary_path(), &payload).unwrap();
+    let bundle = fixture.binary_path().parent().unwrap().join("Fixture.dSYM");
+
+    Command::cargo_bin("atosl")
+        .unwrap()
+        .args([
+            "-o",
+            bundle.to_str().unwrap(),
+            "-l",
+            &format!("0x{:x}", fixture.load_address().unwrap()),
+            &format!("0x{address:x}"),
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("(in fixture_bin)"));
+}
+
 struct Fixture {
     _tempdir: TempDir,
     binary_path: PathBuf,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -82,6 +82,48 @@ fn cli_resolves_dsym_bundle_directory() {
         .stdout(predicates::str::contains("(in fixture_bin)"));
 }
 
+#[test]
+fn cli_reads_addresses_from_stdin() {
+    let fixture = Fixture::build().unwrap();
+    let address = fixture.symbol_address("fixture_target").unwrap();
+
+    Command::cargo_bin("atosl")
+        .unwrap()
+        .args([
+            "-o",
+            fixture.binary_path().to_str().unwrap(),
+            "-l",
+            &format!("0x{:x}", fixture.load_address().unwrap()),
+        ])
+        .write_stdin(format!("0x{address:x}\n"))
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("(in fixture_bin)"));
+}
+
+#[test]
+fn cli_reads_addresses_from_input_file() {
+    let fixture = Fixture::build().unwrap();
+    let address = fixture.symbol_address("fixture_target").unwrap();
+
+    let input_path = fixture.binary_path().parent().unwrap().join("addrs.txt");
+    fs::write(&input_path, format!("0x{address:x}\n")).unwrap();
+
+    Command::cargo_bin("atosl")
+        .unwrap()
+        .args([
+            "-o",
+            fixture.binary_path().to_str().unwrap(),
+            "-l",
+            &format!("0x{:x}", fixture.load_address().unwrap()),
+            "--input",
+            input_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("(in fixture_bin)"));
+}
+
 struct Fixture {
     _tempdir: TempDir,
     binary_path: PathBuf,


### PR DESCRIPTION
## Summary

Expands how `atosl` locates symbols and reads addresses. Four related additions:

1. **`.dSYM` bundle auto-discovery** — pass a `.dSYM` directory to `-o`; the payload under `Contents/Resources/DWARF/` is located automatically (matched by bundle name when several exist).
2. **Directory lookup by UUID / build-id** — when `-o` is a plain directory and `--uuid` is given, recursively scan for a binary or dSYM whose Mach-O UUID or ELF build-id matches, and symbolize it. Non-16-byte hex ids are treated as build-ids (no fat-slice filter imposed).
3. **Separate ELF debug files** — when `-o` is a stripped ELF with no DWARF, follow `.gnu_debuglink` (or build-id) to a companion debug file in the same dir, a `.debug/` subdir, or `/usr/lib/debug`, and symbolize that.
4. **Addresses from stdin or a file** — positional addresses are now optional; when omitted they are read from `--input <FILE>` or stdin (whitespace-separated). Text output streams one result per address; JSON collects a single document.

## Implementation notes

- The object + DWARF context are built once via a shared `Symbolizer`, so streaming reuses the same parsed state per address (no self-referential struct: borrowed state stays in one stack frame).
- Probing a file for a debug companion uses mmap, so large binaries only touch headers.
- The symbol-table fallback and existing batch/JSON output are unchanged; non-inlined frames still omit `inlined_by`, so the macOS Apple goldens are untouched.

## Test plan

- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test`
- [x] New CLI integration tests: dSYM bundle dir, stdin input, `--input` file, directory-by-build-id, `.gnu_debuglink` redirect
- [x] ELF-specific tests (build-id, objcopy/debuglink) are gated to Linux so the macOS runner skips them
- [x] Existing tests and macOS-gated Apple goldens unaffected

https://claude.ai/code/session_01XAne4ituXPChWeo9TjA3z7