### PR TITLE
Add streaming json-lines (ndjson) output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Key options:
 - `--uuid <UUID>`: choose a Mach-O slice by UUID, or select a file from a directory by UUID/build-id
 - `-i, --input <FILE>`: read addresses from a file (defaults to stdin when no addresses are given)
 - `--debug-dir <DIR>`: extra root to search for separate ELF debug files (repeatable)
-- `--format <text|json|json-pretty>`: select output format
+- `--format <text|json|json-pretty|json-lines>`: select output format (`json-lines` emits one ndjson object per address and streams in input mode)
 - `-v, --verbose`: print resolver diagnostics to stderr
 
 ## Examples
@@ -126,6 +126,12 @@ Emit machine-readable output:
 
 ```bash
 atosl -o MyApp.app/MyApp -l 0x100000000 --format json 0x100001234
+```
+
+Stream one JSON object per address (ndjson), e.g. piping a crash log's addresses:
+
+```bash
+cat addresses.txt | atosl -o MyApp.app.dSYM -l 0x100000000 --format json-lines
 ```
 
 Use verbose diagnostics to inspect resolver behavior:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It is designed for cross-platform tooling, CI pipelines, crash-processing utilit
 Apple's `atos` is useful, but it is tightly coupled to Apple's runtime environment. `atosl` focuses on the parts teams usually need in build systems and tooling:
 
 - A single local binary and embeddable Rust API
-- Script-friendly output in `text`, `json`, and `json-pretty`
+- Script-friendly output in `text`, `json`, `json-pretty`, and streaming `json-lines`
 - DWARF-first resolution with symbol-table fallback
 - Fat Mach-O slice selection by architecture or UUID
 - Reproducible regression coverage for Apple-specific behavior
@@ -32,7 +32,7 @@ Apple's `atos` is useful, but it is tightly coupled to Apple's runtime environme
 - Local symbolication from executables, object files, and dSYM payloads
 - Inlined call-stack expansion for DWARF frames, like `atos`
 - Multi-address lookups in a single invocation
-- Addresses from the command line, a file (`--input`), or stdin (streamed in text mode)
+- Addresses from the command line, a file (`--input`), or stdin (streamed in `text` and `json-lines` modes)
 - `.dSYM` bundle directories, or a directory searched by `--uuid` / build-id
 - Separate ELF debug files via CRC-checked `.gnu_debuglink`, build-id, or the debuginfod cache
 - Mach-O fat binaries with explicit slice selection
@@ -204,6 +204,8 @@ let report = atosl::symbolize_path(&SymbolizeOptions {
     arch: None,
     uuid: None,
     format: OutputFormat::Json,
+    input: None,
+    debug_dirs: Vec::new(),
 })?;
 ```
 
@@ -241,7 +243,7 @@ Run the benchmark binary without executing it in CI-style validation:
 cargo bench --bench batch_symbolize --no-run
 ```
 
-Release steps are documented in [RELEASING.md](/Users/eevv/focus/atosl-rs/RELEASING.md).
+Release steps are documented in [RELEASING.md](RELEASING.md).
 For a one-command release flow, run `./deploy.sh [patch|minor|major|X.Y.Z]`.
 
 ## Known limitations

--- a/src/atosl.rs
+++ b/src/atosl.rs
@@ -19,6 +19,8 @@ pub enum OutputFormat {
     Text,
     Json,
     JsonPretty,
+    /// One JSON object per address, one per line (ndjson); streams in input mode.
+    JsonLines,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
@@ -114,10 +116,10 @@ pub fn run(options: SymbolizeOptions) -> Result<i32> {
         return Ok(0);
     }
 
-    // Otherwise read addresses from a file or stdin. Text output streams a
-    // result per address; JSON collects a single document.
+    // Otherwise read addresses from a file or stdin. Text and json-lines stream
+    // a result per address; the single-document JSON formats collect.
     match options.format {
-        OutputFormat::Text => run_streaming_text(&options),
+        OutputFormat::Text | OutputFormat::JsonLines => run_streaming(&options),
         OutputFormat::Json | OutputFormat::JsonPretty => run_collected_input(&options),
     }
 }
@@ -146,22 +148,27 @@ pub fn symbolize_path(options: &SymbolizeOptions) -> Result<SymbolizeReport> {
     })
 }
 
-fn run_streaming_text(options: &SymbolizeOptions) -> Result<i32> {
+fn run_streaming(options: &SymbolizeOptions) -> Result<i32> {
     with_symbolizer(
         options,
         |symbolizer, object_path, selected_slice| -> Result<i32> {
-            if options.verbose {
+            if options.format == OutputFormat::Text && options.verbose {
                 emit_text_header(&object_path, selected_slice.as_ref());
             }
             for_each_input_address(options.input.as_deref(), |parsed| {
-                emit_text_outcome(
-                    &symbolizer.symbolize_parsed(options, parsed),
-                    options.verbose,
-                );
+                let outcome = symbolizer.symbolize_parsed(options, parsed);
+                emit_streaming_outcome(&outcome, options.format, options.verbose);
             })?;
             Ok(0)
         },
     )?
+}
+
+fn emit_streaming_outcome(outcome: &SymbolizeOutcome, format: OutputFormat, verbose: bool) {
+    match format {
+        OutputFormat::JsonLines => println!("{}", serde_json::to_string(outcome).unwrap()),
+        _ => emit_text_outcome(outcome, verbose),
+    }
 }
 
 fn run_collected_input(options: &SymbolizeOptions) -> Result<i32> {
@@ -652,6 +659,11 @@ fn emit_report(report: &SymbolizeReport, format: OutputFormat, verbose: bool) {
         OutputFormat::Text => emit_text_report(report, verbose),
         OutputFormat::Json => println!("{}", serde_json::to_string(report).unwrap()),
         OutputFormat::JsonPretty => println!("{}", serde_json::to_string_pretty(report).unwrap()),
+        OutputFormat::JsonLines => {
+            for frame in &report.frames {
+                println!("{}", serde_json::to_string(frame).unwrap());
+            }
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ enum CliOutputFormat {
     Text,
     Json,
     JsonPretty,
+    JsonLines,
 }
 
 impl From<CliOutputFormat> for OutputFormat {
@@ -16,6 +17,7 @@ impl From<CliOutputFormat> for OutputFormat {
             CliOutputFormat::Text => OutputFormat::Text,
             CliOutputFormat::Json => OutputFormat::Json,
             CliOutputFormat::JsonPretty => OutputFormat::JsonPretty,
+            CliOutputFormat::JsonLines => OutputFormat::JsonLines,
         }
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -54,6 +54,68 @@ fn cli_emits_text_for_resolved_symbol() {
 }
 
 #[test]
+fn cli_emits_json_lines_for_batch() {
+    let fixture = Fixture::build().unwrap();
+    let address = fixture.symbol_address("fixture_target").unwrap();
+    let address_arg = format!("0x{address:x}");
+
+    let output = Command::cargo_bin("atosl")
+        .unwrap()
+        .args([
+            "-o",
+            fixture.binary_path().to_str().unwrap(),
+            "-l",
+            &format!("0x{:x}", fixture.load_address().unwrap()),
+            "--format",
+            "json-lines",
+            &address_arg,
+            &address_arg,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let text = String::from_utf8(output).unwrap();
+    let lines: Vec<&str> = text.lines().filter(|line| !line.is_empty()).collect();
+    assert_eq!(lines.len(), 2);
+    for line in lines {
+        let value: Value = serde_json::from_str(line).unwrap();
+        assert_eq!(value["status"], "resolved");
+        assert_eq!(value["object_name"], "fixture_bin");
+    }
+}
+
+#[test]
+fn cli_streams_json_lines_from_stdin() {
+    let fixture = Fixture::build().unwrap();
+    let address = fixture.symbol_address("fixture_target").unwrap();
+
+    let output = Command::cargo_bin("atosl")
+        .unwrap()
+        .args([
+            "-o",
+            fixture.binary_path().to_str().unwrap(),
+            "-l",
+            &format!("0x{:x}", fixture.load_address().unwrap()),
+            "--format",
+            "json-lines",
+        ])
+        .write_stdin(format!("0x{address:x}\n0x{address:x}\n"))
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let text = String::from_utf8(output).unwrap();
+    assert_eq!(text.lines().filter(|line| !line.is_empty()).count(), 2);
+    let first: Value = serde_json::from_str(text.lines().next().unwrap()).unwrap();
+    assert_eq!(first["status"], "resolved");
+}
+
+#[test]
 fn cli_resolves_dsym_bundle_directory() {
     let fixture = Fixture::build().unwrap();
     let address = fixture.symbol_address("fixture_target").unwrap();


### PR DESCRIPTION
## Summary

Adds a `json-lines` (ndjson) output format for streaming, machine-readable symbolication:

- `--format json-lines` emits **one JSON object per address**, one per line — each line is a `SymbolizeOutcome` (the same schema as an entry in the `frames` array of the `json` report).
- In input mode (stdin / `--input`), results **stream**: a line is printed per address as it is read, so it composes with long-running pipes.
- The batch path (explicit addresses) emits one line per frame.
- The single-document `json` / `json-pretty` formats are unchanged.

This rounds out the input/output streaming story: text and json-lines both stream per address, while json/json-pretty remain single documents.

## Test plan

- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (all green locally)
- [x] New cross-platform CLI tests: batch json-lines emits one valid JSON object per address; stdin streaming emits a line per piped address
- [x] Existing json/json-pretty/text behavior unaffected

https://claude.ai/code/session_01XAne4ituXPChWeo9TjA3z7

---
_Generated by [Claude Code](https://claude.ai/code/session_01XAne4ituXPChWeo9TjA3z7)_