### PR TITLE
Add crash subcommand: symbolicate whole Apple .ips/.crash reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Apple's `atos` is useful, but it is tightly coupled to Apple's runtime environme
 - Addresses from the command line, a file (`--input`), or stdin (streamed in `text` and `json-lines` modes)
 - `.dSYM` bundle directories, or a directory searched by `--uuid` / build-id
 - Separate ELF debug files via CRC-checked `.gnu_debuglink`, build-id, or the debuginfod cache
+- Whole crash-report symbolication for Apple `.ips` and legacy `.crash`, matching each image by UUID
 - Mach-O fat binaries with explicit slice selection
 - Machine-readable integration through JSON output
 - Debugging symbolication decisions through verbose diagnostics
@@ -167,6 +168,27 @@ Example JSON shape:
   ]
 }
 ```
+
+## Symbolicating a whole crash report
+
+The `crash` subcommand symbolicates an entire Apple crash report — modern
+`.ips` (JSON) or legacy `.crash` (text) — rewriting each backtrace frame in
+place. Point it at one or more directories of dSYMs/binaries; every referenced
+image is matched by its UUID (or build-id):
+
+```bash
+atosl crash MyApp-2024.ips --dsym-dir ./dsyms --dsym-dir ./more-dsyms
+```
+
+It reads the report from stdin when no path is given, and writes to stdout (or
+`--output <FILE>`):
+
+```bash
+cat MyApp.crash | atosl crash --dsym-dir ./dsyms > MyApp.symbolicated.crash
+```
+
+Images without a matching dSYM are left untouched, so partial symbol sets still
+produce a usable report.
 
 ## Text output
 

--- a/src/atosl.rs
+++ b/src/atosl.rs
@@ -6,6 +6,7 @@ use object::read::macho::{FatArch, FatHeader};
 use object::{Object, ObjectSection, ObjectSegment, SymbolMap, SymbolMapName};
 use serde::Serialize;
 use std::borrow;
+use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::io::{self, BufRead, BufReader};
@@ -191,7 +192,7 @@ fn run_collected_input(options: &SymbolizeOptions) -> Result<i32> {
     Ok(0)
 }
 
-struct Symbolizer<'a> {
+pub(crate) struct Symbolizer<'a> {
     object_name: &'a str,
     context: Option<&'a DwarfContext<'a>>,
     symbol_map: &'a SymbolMap<SymbolMapName<'a>>,
@@ -199,7 +200,7 @@ struct Symbolizer<'a> {
 }
 
 impl Symbolizer<'_> {
-    fn symbolize(
+    pub(crate) fn symbolize(
         &self,
         load_address: u64,
         requested_address: u64,
@@ -235,7 +236,7 @@ impl Symbolizer<'_> {
 // `body`. Keeping the borrowed state inside one stack frame avoids a
 // self-referential struct (the context borrows the sections, which borrow the
 // mmap).
-fn with_symbolizer<T>(
+pub(crate) fn with_symbolizer<T>(
     options: &SymbolizeOptions,
     body: impl FnOnce(&Symbolizer<'_>, String, Option<SelectedSlice>) -> T,
 ) -> Result<T> {
@@ -535,6 +536,25 @@ fn crc32(data: &[u8]) -> u32 {
     !crc
 }
 
+// Indexes every binary/dSYM under `dirs` by Mach-O UUID and ELF build-id (hex),
+// so crash-log images can be matched in one pass instead of rescanning per image.
+pub(crate) fn index_object_dirs(dirs: &[PathBuf]) -> HashMap<String, PathBuf> {
+    let mut index = HashMap::new();
+    for dir in dirs {
+        let mut candidates = Vec::new();
+        let _ = collect_candidate_files(dir, &mut candidates);
+        candidates.sort();
+        for candidate in candidates {
+            if let Ok(data) = fs::read(&candidate) {
+                for id in collect_module_ids(&data) {
+                    index.entry(id).or_insert_with(|| candidate.clone());
+                }
+            }
+        }
+    }
+    index
+}
+
 fn collect_candidate_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
     let entries = fs::read_dir(dir)
         .with_context(|| format!("failed to read directory: {}", dir.display()))?;
@@ -593,7 +613,7 @@ fn format_hex(bytes: &[u8]) -> String {
     bytes.iter().map(|byte| format!("{byte:02x}")).collect()
 }
 
-fn normalize_hex_id(value: &str) -> String {
+pub(crate) fn normalize_hex_id(value: &str) -> String {
     value
         .chars()
         .filter(|c| c.is_ascii_hexdigit())

--- a/src/crash.rs
+++ b/src/crash.rs
@@ -1,0 +1,307 @@
+//! Whole-crash-report symbolication.
+//!
+//! Parses Apple crash reports (modern `.ips` JSON and legacy `.crash` text),
+//! locates the matching binary/dSYM for each referenced image by UUID/build-id,
+//! and rewrites the report with symbolicated frames.
+
+use crate::atosl::{
+    index_object_dirs, normalize_hex_id, with_symbolizer, OutputFormat, SymbolizeOptions,
+    SymbolizeOutcome, SymbolizedFrame,
+};
+use anyhow::{anyhow, Context as _, Result};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::path::PathBuf;
+
+pub struct CrashSymbolizeOptions {
+    /// Directories of dSYMs/binaries searched per image by UUID/build-id.
+    pub dsym_dirs: Vec<PathBuf>,
+    pub verbose: bool,
+}
+
+#[derive(Debug)]
+struct Image {
+    uuid_hex: Option<String>,
+    base: u64,
+}
+
+/// Symbolicates a crash report, returning the rewritten report text.
+pub fn symbolicate(input: &str, options: &CrashSymbolizeOptions) -> Result<String> {
+    if input.trim_start().starts_with('{') {
+        symbolicate_ips(input, options)
+    } else {
+        Ok(symbolicate_text(input, options))
+    }
+}
+
+// Resolves each image's binary once, symbolizes all of its addresses in a single
+// pass, and returns the outcome for every request keyed by the caller's key.
+fn symbolize_grouped<K: Eq + Hash + Clone>(
+    images: &[Image],
+    requests: &[(K, usize, u64)],
+    options: &CrashSymbolizeOptions,
+) -> HashMap<K, SymbolizeOutcome> {
+    let mut results = HashMap::new();
+    if requests.is_empty() {
+        return results;
+    }
+
+    let index = index_object_dirs(&options.dsym_dirs);
+
+    let mut by_image: HashMap<usize, Vec<(K, u64)>> = HashMap::new();
+    for (key, image_index, address) in requests {
+        by_image
+            .entry(*image_index)
+            .or_default()
+            .push((key.clone(), *address));
+    }
+
+    for (image_index, reqs) in by_image {
+        let Some(image) = images.get(image_index) else {
+            continue;
+        };
+        let Some(uuid_hex) = &image.uuid_hex else {
+            continue;
+        };
+        let Some(object_path) = index.get(&normalize_hex_id(uuid_hex)) else {
+            continue;
+        };
+
+        let opts = SymbolizeOptions {
+            object_path: object_path.clone(),
+            load_address: image.base,
+            addresses: Vec::new(),
+            verbose: options.verbose,
+            file_offsets: false,
+            arch: None,
+            uuid: Some(uuid_hex.clone()),
+            format: OutputFormat::Text,
+            input: None,
+            debug_dirs: options.dsym_dirs.clone(),
+        };
+
+        let addresses: Vec<u64> = reqs.iter().map(|(_, address)| *address).collect();
+        let outcomes = with_symbolizer(&opts, |symbolizer, _, _| {
+            addresses
+                .iter()
+                .map(|address| symbolizer.symbolize(image.base, *address, false))
+                .collect::<Vec<_>>()
+        });
+
+        if let Ok(outcomes) = outcomes {
+            for ((key, _), outcome) in reqs.into_iter().zip(outcomes) {
+                results.insert(key, outcome);
+            }
+        }
+    }
+
+    results
+}
+
+fn symbolicate_ips(input: &str, options: &CrashSymbolizeOptions) -> Result<String> {
+    let (header, body_str) = input
+        .split_once('\n')
+        .ok_or_else(|| anyhow!("ips report is missing its body after the header line"))?;
+    let mut body: Value =
+        serde_json::from_str(body_str.trim()).context("failed to parse ips report body as JSON")?;
+
+    let images = parse_ips_images(&body)?;
+
+    let mut requests: Vec<((usize, usize), usize, u64)> = Vec::new();
+    if let Some(threads) = body.get("threads").and_then(Value::as_array) {
+        for (t, thread) in threads.iter().enumerate() {
+            let Some(frames) = thread.get("frames").and_then(Value::as_array) else {
+                continue;
+            };
+            for (f, frame) in frames.iter().enumerate() {
+                let (Some(idx), Some(offset)) = (
+                    frame.get("imageIndex").and_then(Value::as_u64),
+                    frame.get("imageOffset").and_then(Value::as_u64),
+                ) else {
+                    continue;
+                };
+                let idx = idx as usize;
+                if let Some(image) = images.get(idx) {
+                    requests.push(((t, f), idx, image.base.wrapping_add(offset)));
+                }
+            }
+        }
+    }
+
+    let results = symbolize_grouped(&images, &requests, options);
+
+    if let Some(threads) = body.get_mut("threads").and_then(Value::as_array_mut) {
+        for (t, thread) in threads.iter_mut().enumerate() {
+            let Some(frames) = thread.get_mut("frames").and_then(Value::as_array_mut) else {
+                continue;
+            };
+            for (f, frame) in frames.iter_mut().enumerate() {
+                if let Some(SymbolizeOutcome::Resolved(resolved)) = results.get(&(t, f)) {
+                    apply_ips_frame(frame, resolved);
+                }
+            }
+        }
+    }
+
+    let serialized = serde_json::to_string(&body).context("failed to serialize ips report")?;
+    Ok(format!("{header}\n{serialized}"))
+}
+
+fn parse_ips_images(body: &Value) -> Result<Vec<Image>> {
+    let images = body
+        .get("usedImages")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow!("ips report has no usedImages array"))?;
+    Ok(images
+        .iter()
+        .map(|image| Image {
+            uuid_hex: image
+                .get("uuid")
+                .and_then(Value::as_str)
+                .map(normalize_hex_id),
+            base: image.get("base").and_then(Value::as_u64).unwrap_or(0),
+        })
+        .collect())
+}
+
+fn apply_ips_frame(frame: &mut Value, resolved: &SymbolizedFrame) {
+    let Some(object) = frame.as_object_mut() else {
+        return;
+    };
+    object.insert("symbol".to_string(), Value::String(resolved.symbol.clone()));
+    object.insert("symbolLocation".to_string(), Value::from(resolved.offset));
+    if let Some(location) = &resolved.location {
+        object.insert(
+            "sourceFile".to_string(),
+            Value::String(location.file.clone()),
+        );
+        object.insert("sourceLine".to_string(), Value::from(location.line));
+    }
+}
+
+fn symbolicate_text(input: &str, options: &CrashSymbolizeOptions) -> String {
+    let lines: Vec<&str> = input.lines().collect();
+    let (images, name_to_index) = parse_text_images(&lines);
+
+    struct FrameLine {
+        line_index: usize,
+        prefix: String,
+        image_index: usize,
+        address: u64,
+    }
+
+    let mut frame_lines: Vec<FrameLine> = Vec::new();
+    for (line_index, line) in lines.iter().enumerate() {
+        if let Some((prefix, name, address)) = parse_frame_line(line) {
+            if let Some(&image_index) = name_to_index.get(name.as_str()) {
+                frame_lines.push(FrameLine {
+                    line_index,
+                    prefix,
+                    image_index,
+                    address,
+                });
+            }
+        }
+    }
+
+    let requests: Vec<(usize, usize, u64)> = frame_lines
+        .iter()
+        .map(|frame| (frame.line_index, frame.image_index, frame.address))
+        .collect();
+    let results = symbolize_grouped(&images, &requests, options);
+
+    let mut rewritten: HashMap<usize, String> = HashMap::new();
+    for frame in &frame_lines {
+        if let Some(SymbolizeOutcome::Resolved(resolved)) = results.get(&frame.line_index) {
+            rewritten.insert(
+                frame.line_index,
+                format!("{} {}", frame.prefix, format_crash_symbol(resolved)),
+            );
+        }
+    }
+
+    let mut output = String::with_capacity(input.len());
+    for (line_index, line) in lines.iter().enumerate() {
+        match rewritten.get(&line_index) {
+            Some(replacement) => output.push_str(replacement),
+            None => output.push_str(line),
+        }
+        output.push('\n');
+    }
+    output
+}
+
+// Parses the "Binary Images:" table, returning the images and a name->index map.
+fn parse_text_images<'a>(lines: &[&'a str]) -> (Vec<Image>, HashMap<&'a str, usize>) {
+    let mut images = Vec::new();
+    let mut name_to_index = HashMap::new();
+
+    let Some(start) = lines
+        .iter()
+        .position(|line| line.trim_start().starts_with("Binary Images:"))
+    else {
+        return (images, name_to_index);
+    };
+
+    for line in &lines[start + 1..] {
+        if line.trim().is_empty() {
+            break;
+        }
+        if let Some((name, image)) = parse_text_image_line(line) {
+            name_to_index.entry(name).or_insert(images.len());
+            images.push(image);
+        }
+    }
+
+    (images, name_to_index)
+}
+
+fn parse_text_image_line(line: &str) -> Option<(&str, Image)> {
+    // 0xSTART - 0xEND  name arch  <uuid>  /path
+    let tokens: Vec<&str> = line.split_whitespace().collect();
+    if tokens.len() < 6 || tokens[1] != "-" {
+        return None;
+    }
+    let base = parse_hex(tokens[0])?;
+    let name = tokens[3].trim_start_matches('+');
+    let uuid_token = tokens[5];
+    let uuid_hex = uuid_token
+        .starts_with('<')
+        .then(|| normalize_hex_id(uuid_token));
+    Some((name, Image { uuid_hex, base }))
+}
+
+fn parse_frame_line(line: &str) -> Option<(String, String, u64)> {
+    // FRAME_NO  image_name  0xADDRESS  <unsymbolicated detail>
+    let tokens: Vec<&str> = line.split_whitespace().collect();
+    if tokens.len() < 4 || !tokens[0].bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    let address_token = tokens[2];
+    if !address_token.starts_with("0x") && !address_token.starts_with("0X") {
+        return None;
+    }
+    let address = parse_hex(address_token)?;
+    let address_end = line.find(address_token)? + address_token.len();
+    Some((
+        line[..address_end].to_string(),
+        tokens[1].to_string(),
+        address,
+    ))
+}
+
+fn format_crash_symbol(frame: &SymbolizedFrame) -> String {
+    match &frame.location {
+        Some(location) => format!("{} ({}:{})", frame.symbol, location.file, location.line),
+        None => format!("{} + {}", frame.symbol, frame.offset),
+    }
+}
+
+fn parse_hex(token: &str) -> Option<u64> {
+    let value = token
+        .strip_prefix("0x")
+        .or_else(|| token.strip_prefix("0X"))
+        .unwrap_or(token);
+    u64::from_str_radix(value, 16).ok()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,9 +27,11 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
 pub mod atosl;
+pub mod crash;
 pub mod demangle;
 
 pub use atosl::{
     InlineFrame, OutputFormat, ResolverKind, SelectedSlice, SourceLocation, SymbolizeOptions,
     SymbolizeOutcome, SymbolizeReport, SymbolizedFrame,
 };
+pub use crash::{symbolicate, CrashSymbolizeOptions};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
-use atosl::{OutputFormat, SymbolizeOptions};
+use atosl::{CrashSymbolizeOptions, OutputFormat, SymbolizeOptions};
 use clap::{Parser, ValueEnum};
+use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::process;
+use std::{fs, io};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
 enum CliOutputFormat {
@@ -22,9 +24,36 @@ impl From<CliOutputFormat> for OutputFormat {
     }
 }
 
+/// Symbolicate a whole crash report (.ips or legacy .crash text).
+///
+/// Invoked as `atosl crash <REPORT>`; the `crash` token is routed before the
+/// default address-symbolication parser so it never collides with positional
+/// addresses.
+#[derive(Parser, Debug)]
+#[command(name = "atosl crash", about)]
+struct CrashArgs {
+    /// Crash report path (.ips or .crash); reads stdin when omitted
+    crash_path: Option<PathBuf>,
+
+    /// Directory of dSYMs/binaries to match report images by UUID (repeatable)
+    #[arg(short = 'd', long = "dsym-dir")]
+    dsym_dir: Vec<PathBuf>,
+
+    /// Write the symbolicated report here (defaults to stdout)
+    #[arg(short = 'o', long = "output")]
+    output: Option<PathBuf>,
+
+    /// Enable verbose diagnostics
+    #[arg(short, long)]
+    verbose: bool,
+}
+
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
-struct Args {
+#[command(
+    after_help = "Run `atosl crash <REPORT> --dsym-dir <DIR>` to symbolicate a whole crash report."
+)]
+struct SymbolizeArgs {
     /// Symbol file path or binary file path
     #[arg(short = 'o', long = "object", value_name = "OBJECT_PATH")]
     object_path: PathBuf,
@@ -80,7 +109,30 @@ fn parse_address_string(address: &str) -> Result<u64, String> {
 }
 
 fn main() {
-    let args = Args::parse();
+    // Route `atosl crash ...` to the crash parser before the default parser, so
+    // the report path never competes with positional addresses.
+    let mut argv: Vec<std::ffi::OsString> = std::env::args_os().collect();
+    let is_crash = argv.get(1).map(|arg| arg == "crash").unwrap_or(false);
+
+    let result = if is_crash {
+        argv.remove(1);
+        run_crash(CrashArgs::parse_from(argv))
+    } else {
+        run_symbolize(SymbolizeArgs::parse())
+    };
+
+    let exit_code = match result {
+        Ok(code) => code,
+        Err(err) => {
+            eprintln!("{err:#}");
+            1
+        }
+    };
+
+    process::exit(exit_code);
+}
+
+fn run_symbolize(args: SymbolizeArgs) -> anyhow::Result<i32> {
     let options = SymbolizeOptions {
         object_path: args.object_path,
         load_address: args.load_address,
@@ -94,15 +146,41 @@ fn main() {
         debug_dirs: args.debug_dir,
     };
 
-    let exit_code = match atosl::atosl::run(options) {
-        Ok(code) => code,
-        Err(err) => {
-            eprintln!("{err:#}");
-            1
+    atosl::atosl::run(options)
+}
+
+fn run_crash(args: CrashArgs) -> anyhow::Result<i32> {
+    use anyhow::Context as _;
+
+    let input = match &args.crash_path {
+        Some(path) => fs::read_to_string(path)
+            .with_context(|| format!("failed to read crash report: {}", path.display()))?,
+        None => {
+            let mut buffer = String::new();
+            io::stdin()
+                .read_to_string(&mut buffer)
+                .context("failed to read crash report from stdin")?;
+            buffer
         }
     };
 
-    process::exit(exit_code);
+    let report = atosl::symbolicate(
+        &input,
+        &CrashSymbolizeOptions {
+            dsym_dirs: args.dsym_dir,
+            verbose: args.verbose,
+        },
+    )?;
+
+    match &args.output {
+        Some(path) => fs::write(path, report)
+            .with_context(|| format!("failed to write symbolicated report: {}", path.display()))?,
+        None => io::stdout()
+            .write_all(report.as_bytes())
+            .context("failed to write symbolicated report")?,
+    }
+
+    Ok(0)
 }
 
 #[cfg(test)]

--- a/tests/crash.rs
+++ b/tests/crash.rs
@@ -1,0 +1,147 @@
+use assert_cmd::Command;
+use object::{Object, ObjectSection, ObjectSymbol};
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use std::process::Command as ProcessCommand;
+
+const BUILD_ID: &str = "abcdef0123456789abcdef0123456789abcdef01";
+const BASE: u64 = 0x1_0000_0000;
+
+#[test]
+fn symbolicates_legacy_text_crash() {
+    if !cfg!(target_os = "linux") {
+        return;
+    }
+
+    let tempdir = tempfile::tempdir().unwrap();
+    let dsym_dir = tempdir.path().join("symbols");
+    fs::create_dir_all(&dsym_dir).unwrap();
+    let bin = dsym_dir.join("app");
+    build_fixture(tempdir.path(), &bin);
+
+    let image_offset = symbol_addr(&bin, "fixture_target") - text_addr(&bin);
+    let runtime = BASE + image_offset;
+
+    let report = format!(
+        "Thread 0 Crashed:\n\
+         0   app   0x{runtime:016x}   0x{BASE:x} + {image_offset}\n\
+         \n\
+         Binary Images:\n\
+         0x{BASE:x} - 0x{end:x}  app arm64  <{BUILD_ID}>  /tmp/app\n",
+        end = BASE + 0x1000,
+    );
+    let report_path = tempdir.path().join("crash.crash");
+    fs::write(&report_path, report).unwrap();
+
+    Command::cargo_bin("atosl")
+        .unwrap()
+        .args([
+            "crash",
+            report_path.to_str().unwrap(),
+            "--dsym-dir",
+            dsym_dir.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("0   app   "))
+        .stdout(predicates::str::contains("fixture_target"));
+}
+
+#[test]
+fn symbolicates_ips_crash() {
+    if !cfg!(target_os = "linux") {
+        return;
+    }
+
+    let tempdir = tempfile::tempdir().unwrap();
+    let dsym_dir = tempdir.path().join("symbols");
+    fs::create_dir_all(&dsym_dir).unwrap();
+    let bin = dsym_dir.join("app");
+    build_fixture(tempdir.path(), &bin);
+
+    let image_offset = symbol_addr(&bin, "fixture_target") - text_addr(&bin);
+
+    let body = serde_json::json!({
+        "usedImages": [
+            { "base": BASE, "uuid": BUILD_ID, "name": "app", "arch": "arm64" }
+        ],
+        "threads": [
+            { "frames": [ { "imageIndex": 0, "imageOffset": image_offset } ] }
+        ]
+    });
+    let report = format!("{{\"app_name\":\"app\"}}\n{body}");
+    let report_path = tempdir.path().join("crash.ips");
+    fs::write(&report_path, report).unwrap();
+
+    let output = Command::cargo_bin("atosl")
+        .unwrap()
+        .args([
+            "crash",
+            report_path.to_str().unwrap(),
+            "--dsym-dir",
+            dsym_dir.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let text = String::from_utf8(output).unwrap();
+    let body_line = text
+        .lines()
+        .nth(1)
+        .expect("ips output should keep a body line");
+    let parsed: Value = serde_json::from_str(body_line).unwrap();
+    assert_eq!(
+        parsed["threads"][0]["frames"][0]["symbol"],
+        Value::String("fixture_target".to_string())
+    );
+}
+
+fn build_fixture(workdir: &Path, out: &Path) {
+    let src = workdir.join("f.c");
+    fs::write(
+        &src,
+        "int fixture_target(void){return 7;}\nint main(void){return fixture_target();}\n",
+    )
+    .unwrap();
+    let status = ProcessCommand::new("cc")
+        .args([
+            "-g",
+            "-O0",
+            &format!("-Wl,--build-id=0x{BUILD_ID}"),
+            src.to_str().unwrap(),
+            "-o",
+            out.to_str().unwrap(),
+        ])
+        .status()
+        .unwrap();
+    assert!(
+        status.success(),
+        "failed to build fixture {}",
+        out.display()
+    );
+}
+
+fn symbol_addr(path: &Path, name: &str) -> u64 {
+    let bytes = fs::read(path).unwrap();
+    let object = object::File::parse(bytes.as_slice()).unwrap();
+    object
+        .symbols()
+        .chain(object.dynamic_symbols())
+        .find(|symbol| symbol.name().map(|n| n.contains(name)).unwrap_or(false))
+        .map(|symbol| symbol.address())
+        .unwrap()
+}
+
+fn text_addr(path: &Path) -> u64 {
+    let bytes = fs::read(path).unwrap();
+    let object = object::File::parse(bytes.as_slice()).unwrap();
+    object
+        .section_by_name(".text")
+        .or_else(|| object.section_by_name("__text"))
+        .map(|section| section.address())
+        .unwrap()
+}


### PR DESCRIPTION
## Summary

Adds a `crash` subcommand that symbolicates an **entire Apple crash report** and rewrites it in place:

- **Both formats** — modern `.ips` (JSON metadata line + JSON body with `usedImages`/`threads`) and legacy `.crash` (text `Binary Images:` table + thread frames). Format is auto-detected.
- **Per-image symbol matching** — every referenced image is matched against one or more `--dsym-dir` directories by Mach-O **UUID** or ELF **build-id**. The directories are indexed once, then each image's frames are symbolized in a single pass through the existing engine (so dSYM/debuglink/fat-slice handling all apply).
- **In-place rewrite** — `.ips` frames gain `symbol`/`symbolLocation`/`sourceFile`/`sourceLine`; `.crash` frame lines get their trailing detail replaced with `symbol (file:line)` (or `symbol + offset`). Images without a matching dSYM are left untouched, so partial symbol sets still yield a usable report.
- **I/O** — reads a report path or stdin; writes stdout or `--output <FILE>`.

Usage:

```bash
atosl crash MyApp-2024.ips --dsym-dir ./dsyms
cat MyApp.crash | atosl crash --dsym-dir ./dsyms > MyApp.symbolicated.crash
```

## Implementation notes

- New `src/crash.rs` module; reuses `with_symbolizer`, the directory UUID/build-id index, and `normalize_hex_id` (now `pub(crate)`).
- The `crash` token is routed to its own parser before the default address parser, so the report path never competes with the top-level positional `addresses` (clap can't disambiguate a bare positional from a subcommand). The flat `atosl -o ... -l ... <addr>` interface is unchanged.
- Remote/HTTP debuginfod is still out of scope; image lookup uses local `--dsym-dir` directories (and the existing debuginfod cache via the engine).

## Test plan

- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (all green locally)
- [x] New Linux-gated integration tests symbolicate a real ELF fixture (matched by build-id) through both the `.crash` text and `.ips` JSON paths end-to-end
- [x] Existing 12 CLI tests and the flat interface unaffected

Note: real-world Apple `.ips`/`.crash` files reference Mach-O images, which can only be exercised end-to-end on macOS; the Linux CI tests cover the parsers and the full orchestration via build-id-matched ELF fixtures.

https://claude.ai/code/session_01XAne4ituXPChWeo9TjA3z7

---
_Generated by [Claude Code](https://claude.ai/code/session_01XAne4ituXPChWeo9TjA3z7)_